### PR TITLE
Fixed loader issue in Rails 5.2.3

### DIFF
--- a/lib/scout_signalfx.rb
+++ b/lib/scout_signalfx.rb
@@ -1,3 +1,5 @@
+require 'scout_apm'
+
 module ScoutSignalfx
   # Takes a +SignalFxClient+ and configures the ScoutApm SignalFx Payload Plugin.
   def self.configure(signalfx_client)


### PR DESCRIPTION
When the Gem was loaded in Rails 5.2.3, the following error message was being thrown....

```
.../gems/bootsnap-1.4.4/lib/bootsnap/load_path_cache/core_ext/active_support.rb:79:in `block in load_missing_constant': uninitialized constant ScoutSignalfx::ScoutApm (NameError)
```

Tracing back, the code in the app that causes the issue is:
```ruby 
ScoutSignalfx.configure(SIGNAL_FX_CLIENT)
```

Without the require, Ruby is looking for `ScoutApm` in the `ScoutSignalFx` namespace.  Adding the require fixes the loading issue.